### PR TITLE
Quote CMAKE_BUILD_TYPE in CMakeLists.txt to allow it being unset.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
-if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
 	message("Debug build")
 	add_definitions(-DDEBUG_BUILD)
 endif()


### PR DESCRIPTION
Right now, cmake will fail when called without defining CMAKE_BUILD_TYPE with

```
CMake Error at CMakeLists.txt:15 (if):
  if given arguments:

    "STREQUAL" "Debug"

  Unknown arguments specified
```

Quoting the variable will make cmake pass. This is super-trivial and maybe not what you want.
Then I would suggest to set a default build type instead, or ignoring this pull request. :-)