### PR TITLE
Fix for incorrect index into descriptor array argument

### DIFF
--- a/driver/descriptorSet.c
+++ b/driver/descriptorSet.c
@@ -439,9 +439,9 @@ VKAPI_ATTR void VKAPI_CALL RPIFUNC(vkCmdBindDescriptorSets)(
 	_pipelineLayout* pl = layout;//pipelineBindPoint == VK_PIPELINE_BIND_POINT_GRAPHICS ? cb->graphicsPipeline->layout : cb->computePipeline->layout;
 	assert(firstSet + descriptorSetCount <= pl->setLayoutCount);
 
-	for(uint32_t c = firstSet; c < firstSet + descriptorSetCount; ++c)
+	for(uint32_t c = 0; c < descriptorSetCount; ++c)
 	{
-		setMapElement(&pl->descriptorSetBindingMap, c, pDescriptorSets[c]);
+		setMapElement(&pl->descriptorSetBindingMap, firstSet + c, pDescriptorSets[c]);
 	}
 
 	cb->descriptorSetDirty = 1;


### PR DESCRIPTION
Hello,

I ran into a bug today when trying to bind 1 descriptor set to a pipeline layout that has 2 sets. The problem is that the current implementation expects the length of the input descriptor array passed into vkCmdBindDescriptorSets to match the number of sets in the layout, which I don't believe is necessary? In my case, I was trying to set the 2nd descriptor set in the layout by passing an array with only a single set. Not sure if I explained that too well, hopefully more obvious from the code.

Cheers,
Pete
 