### PR TITLE
triangle test: move the createWindowSurface() and createSwapChain() calls

### DIFF
--- a/test/triangle/triangle.cpp
+++ b/test/triangle/triangle.cpp
@@ -136,6 +136,8 @@ void setupVulkan() {
 	findPhysicalDevice();
 	findQueueFamilies();
 	createLogicalDevice();
+	createWindowSurface();
+	createSwapChain();
 
 	VkDescriptorPoolSize ps[2];
 	ps[0].descriptorCount = 1;
@@ -181,10 +183,8 @@ void setupVulkan() {
 	vkDestroyDescriptorPool(device, dp, 0);
 
 	CreateShaders();
-	createWindowSurface();
 	checkSwapChainSupport();
 	createSemaphores();
-	createSwapChain();
 	createCommandQueues();
 	CreateRenderPass();
 	CreateFramebuffer();


### PR DESCRIPTION
This change calls createWindowSurface () and createSwapChain () earlier in the triangle test (which is the case in other tests).

Nicolas Caramelli